### PR TITLE
Warning error cleanup

### DIFF
--- a/lib/conf/setup.js
+++ b/lib/conf/setup.js
@@ -1,5 +1,5 @@
 var fs = require('fs');
-var prompt = require('sync-prompt').prompt;
+var readline = require('readline-sync');
 
 var Setup = function() {};
 
@@ -22,9 +22,9 @@ Setup.prototype = {
 	},
 	gatherConfig: function() {
 		console.log("Configure your first build:");
-		var teamcityServer = prompt('What is your Teamcity Server? (ip/fqdn and port.  No http)\r\n --> ');
-		var id = prompt('What is the buildtype id? \r\n --> ');
-		var name = prompt('What is the friendly name of this build? \r\n --> ');
+		var teamcityServer = readline.question('What is your Teamcity Server? (ip/fqdn and port. No http) :');
+		var id = readline.question('What is the buildtype id? :');
+		var name = readline.question('What is the friendly name of this build? :');
 
 		var config = {};
 		config.teamcityHost = teamcityServer;

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
         "node-inspector": "0.1.10"
     },
     "bundleDependencies": [],
+    "license": "MIT",
     "licenses": [
         {
           "type": "MIT",

--- a/package.json
+++ b/package.json
@@ -28,23 +28,25 @@
     "preferGlobal": "true",
     "dependencies": {
         "seq": "0.3.5",
-        "request": "2.9.x",
-        "sprintf": "0.1.0",
-        "express": "3.x",
-        "nconf": "0.6.x",
+        "request": "2.67.x",
+        "sprintf": "0.1.x",
+        "express": "4.13.x",
+        "nconf": "0.8.x",
         "colors": "*",
-        "node-blink1": "0.1.x",
-        "forever": "0.10.x",
-        "prettyjson": "0.12.x",
-        "moment": "2.5.x",
-        "sync-prompt": "0.2.x"
+        "node-blink1": "0.2.x",
+        "forever": "0.15.x",
+        "prettyjson": "1.1.x",
+        "moment": "2.10.x",
+        "readline-sync": "1.2.x"
     },
+    "_comment": "I removed sync-prompt: 0.4.x above",
+
     "noAnalyze": true,
     "devDependencies": {
-        "nodeunit": "0.7.x",
-        "should": "0.6.x",
-        "mocha": "1.2.1",
-        "node-inspector": "0.1.10"
+        "nodeunit": "0.9.x",
+        "should": "8.0.x",
+        "mocha": "2.3.x",
+        "node-inspector": "0.12.x"
     },
     "bundleDependencies": [],
     "license": "MIT",

--- a/test/BuildActivityTest.js
+++ b/test/BuildActivityTest.js
@@ -11,7 +11,6 @@ suite('BuildActivity', function() {
 		// config = JSON.parse(fs.readFileSync('./conf/default/config.json', "utf8"));
 	});
 
-
 	suite('should_correctly_identify_state_of_build', function() {
 		test('should_identify_green_build', function() {
 			var buildJson = JSON.parse(fs.readFileSync('./test/samples/teamcityApi/success.json', "utf8"));
@@ -34,8 +33,6 @@ suite('BuildActivity', function() {
 			activity.should.have.property('isBuilding', true);
 			activity.should.have.property('isBuildingFromRed', false);
 			activity.should.have.property('isBuildingFromGreen', true);
-			
-
 		});
 
 		test('should_identify_as_building_from_red', function() {
@@ -49,8 +46,6 @@ suite('BuildActivity', function() {
 			activity.should.have.property('isBuilding', true);
 			activity.should.have.property('isBuildingFromRed', true);
 			activity.should.have.property('isBuildingFromGreen', false);
-
-
 		});
 
 		test('should_identify_red_build', function() {
@@ -64,23 +59,13 @@ suite('BuildActivity', function() {
 			activity.should.have.property('isBuilding', false);
 			activity.should.have.property('isRed', true);
 			console.log(JSON.stringify(activity));
-
-
 		});
-
 
 		test('should_have_proper_build_token', function() {
 			var buildJson = JSON.parse(fs.readFileSync('./test/samples/teamcityApi/redBuild.json', "utf8"));
 			var activity = new BuildActivity(buildJson);
 
 			activity.should.have.property('instanceToken', 'bt4:83');
-
-
 		});
-
-
-
 	});
-
-
 });

--- a/test/TeamcityServiceTest.js
+++ b/test/TeamcityServiceTest.js
@@ -2,6 +2,7 @@ var assert = require('assert');
 var should = require('should');
 
 var TeamCityService = require('./../lib/services/TeamCityService.js');
+var TeamCityGateway = require('./../lib/gateways/TeamCityGateway.js');
 var fs = require('fs');
 
 suite('TeamCityService', function() {
@@ -10,13 +11,15 @@ suite('TeamCityService', function() {
 	var mockGateway;
 
 	setup(function() {
+    mockGateway = new TeamCityGateway('127.0.0.1');
 		config = JSON.parse(fs.readFileSync('./lib/conf/config.json', "utf8"));
 		service = new TeamCityService(config,mockGateway);
 	});
 
 	suite('constructor', function() {
 		test('should_create_TeamCityService', function() {
-			service.should.be.a('object').and.have.property('gateway', mockGateway);
+			//service.should.be.a('object').and.have.property('gateway', mockGateway);
+      service.should.be.an.instanceOf(Object).and.have.property('gateway', mockGateway);
 		});
 	});
 


### PR DESCRIPTION
On my Mac (10.10.5) using node-5.30. and npm-3.3.12 I had trouble getting the project to work and there were a few warnings as well.

I attempted to clean up some warnings, updated dependencies, and placed sync-prompt in favor of readline-sync (solely because sync-prompt couldn't install/run on my machine).
